### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
   #         npm run build
 
   #     - name: Archive Production Artifact
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: build
   #         path: build


### PR DESCRIPTION
### Description

In this pull request, the version of the GitHub Action 'actions/upload-artifact' is updated from v3 to v4 in the build workflow file.

- Update the version of the GitHub Action 'actions/upload-artifact' from v3 to v4 in the build workflow file.